### PR TITLE
Optimize some Julia benchmarks

### DIFF
--- a/Keller_Miksis_RK45/CPU_Julia/CPU_KellerMiksis_julia.jl
+++ b/Keller_Miksis_RK45/CPU_Julia/CPU_KellerMiksis_julia.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations, DelimitedFiles, Plots, CPUTime
+using DifferentialEquations, DelimitedFiles, Plots, CPUTime, MuladdMacro
 
 const numberOfRuns = 3
 const numberOfParameters = 256
@@ -63,7 +63,7 @@ end
 
 #ensemble problem
 function prob_func!(problem,i,repeat)
-    @inbounds begin
+    @inbounds @muladd begin
         #calculating indexes
         problem.u0[1] = initialValues[i,1]
         problem.u0[2] = initialValues[i,2]
@@ -110,6 +110,7 @@ res = solve(
 	dense = false,
 	maxiters = 1e10,
 	dtmin = 1e-10)
+GC.gc()
 
 #solving ODE 3x and measuring elapsed CPU time
 times = Vector{Float64}(undef,numberOfRuns)

--- a/Keller_Miksis_RK45/CPU_Julia/CPU_KellerMiksis_julia.jl
+++ b/Keller_Miksis_RK45/CPU_Julia/CPU_KellerMiksis_julia.jl
@@ -93,6 +93,24 @@ function prob_func!(problem,i,repeat)
     problem
 end
 
+# Compile once
+tSpan = (0.0,1024.0)
+prob = ODEProblem(keller_miksis!,y0,tSpan,C)
+ensemble_prob = EnsembleProblem(prob,prob_func = prob_func!)
+res = solve(
+	ensemble_prob,
+	DP5(),
+	EnsembleSerial(),
+	abstol = 1e-10,
+	reltol = 1e-10,
+	trajectories= numberOfParameters,
+	save_everystep = false,
+	save_start = false,
+	save_end = true,
+	dense = false,
+	maxiters = 1e10,
+	dtmin = 1e-10)
+
 #solving ODE 3x and measuring elapsed CPU time
 times = Vector{Float64}(undef,numberOfRuns)
 for runs in 1:numberOfRuns

--- a/Keller_Miksis_RK45/CPU_Julia/CPU_KellerMiksis_julia.jl
+++ b/Keller_Miksis_RK45/CPU_Julia/CPU_KellerMiksis_julia.jl
@@ -42,7 +42,7 @@ y0 = [1.0,0.0] #inital conditions
 
 #ODE system
 function keller_miksis!(dy,y,C,τ)
-    @inbounds begin
+    @inbounds @muladd begin
         rx1 = 1/y[1]
         p = rx1 ^ C[10]
 

--- a/Keller_Miksis_RK45/GPU_Julia/GPU_KellerMiksis_julia.jl
+++ b/Keller_Miksis_RK45/GPU_Julia/GPU_KellerMiksis_julia.jl
@@ -116,6 +116,7 @@ res = solve(
 	dense = false,
 	maxiters = 1e10,
 	dtmin = 1e-10)
+GC.gc()
 
 #solving ODE 3x and measuring elapsed CPU time
 times = Vector{Float64}(undef,numberOfRuns)

--- a/Lorenz_RK4/CPU_Julia/CPU_Lorenz_julia.jl
+++ b/Lorenz_RK4/CPU_Julia/CPU_Lorenz_julia.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations, CPUTime, Statistics, MuladdMacro
+using DifferentialEquations, CPUTime, Statistics, LoopVectorization
 
 #settings
 const unroll = 128
@@ -17,7 +17,7 @@ end
 
 #ODE
 function lorenz!(du, u, p, t)
-    @muladd @inbounds for j in 1:unroll
+    @avx for j in 1:unroll
       du[j] = 10.0 * (u[j+unroll] - u[j])
       du[j+unroll] = p[j] * u[j] - u[j+unroll] - u[j] * u[j+2*unroll]
       du[j+2*unroll] = u[j] * u[j+unroll] - 2.66666666 * u[j+2*unroll]

--- a/Lorenz_RK4/CPU_Julia/CPU_Lorenz_julia.jl
+++ b/Lorenz_RK4/CPU_Julia/CPU_Lorenz_julia.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations, CPUTime, Statistics
+using DifferentialEquations, CPUTime, Statistics, MuladdMacro
 
 #settings
 const unroll = 128
@@ -17,12 +17,11 @@ end
 
 #ODE
 function lorenz!(du, u, p, t)
-  @inbounds for j in 1:unroll
-      index = 3(j-1)+1
-      du[index] = 10.0 * (u[index+1] - u[index])
-      du[index+1] = p[j] * u[index] - u[index+1] - u[index] * u[index+2]
-      du[index+2] = u[index] * u[index+1] - 2.66666666 * u[index+2]
-  end
+    @muladd @inbounds for j in 1:unroll
+      du[j] = 10.0 * (u[j+unroll] - u[j])
+      du[j+unroll] = p[j] * u[j] - u[j+unroll] - u[j] * u[j+2*unroll]
+      du[j+2*unroll] = u[j] * u[j+unroll] - 2.66666666 * u[j+2*unroll]
+   end
 end
 
 #compile
@@ -39,6 +38,7 @@ solve(
   dt = 0.01,
   unstable_check = nocheck
   )
+GC.gc()
 
 #simulation
 times = Vector{Float64}(undef,numberOfRuns)

--- a/Lorenz_RK4/CPU_Julia/CPU_Lorenz_julia_ensemble.jl
+++ b/Lorenz_RK4/CPU_Julia/CPU_Lorenz_julia_ensemble.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations, CPUTime, Statistics
+using DifferentialEquations, CPUTime, Statistics, MuladdMacro
 
 #settings
 const unroll = 128
@@ -14,12 +14,11 @@ u0 = ones(3*unroll,1)*10
 
 #ODE
 function lorenz!(du, u, p, t)
-  @inbounds for j in 1:128
-    index = 3(j-1)+1
-    du[index] = 10.0 * (u[index+1] - u[index])
-    du[index+1] = p[j] * u[index] - u[index+1] - u[index] * u[index+2]
-    du[index+2] = u[index] * u[index+1] - 2.66666666 * u[index+2]
-  end
+    @muladd @inbounds for j in 1:unroll
+      du[j] = 10.0 * (u[j+unroll] - u[j])
+      du[j+unroll] = p[j] * u[j] - u[j+unroll] - u[j] * u[j+2*unroll]
+      du[j+2*unroll] = u[j] * u[j+unroll] - 2.66666666 * u[j+2*unroll]
+   end
 end
 
 #parameter change function
@@ -48,6 +47,7 @@ solve(
   dense = false,
   unstable_check = nocheck,
   )
+GC.gc()
 
 #simulation
 times = Vector{Float64}(undef,numberOfRuns)

--- a/Lorenz_RK4/CPU_Julia/CPU_Lorenz_julia_ensemble.jl
+++ b/Lorenz_RK4/CPU_Julia/CPU_Lorenz_julia_ensemble.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations, CPUTime, Statistics, MuladdMacro
+using DifferentialEquations, CPUTime, Statistics, LoopVectorization
 
 #settings
 const unroll = 128
@@ -14,7 +14,7 @@ u0 = ones(3*unroll,1)*10
 
 #ODE
 function lorenz!(du, u, p, t)
-    @muladd @inbounds for j in 1:unroll
+    @avx for j in 1:unroll
       du[j] = 10.0 * (u[j+unroll] - u[j])
       du[j+unroll] = p[j] * u[j] - u[j+unroll] - u[j] * u[j+2*unroll]
       du[j+2*unroll] = u[j] * u[j+unroll] - 2.66666666 * u[j+2*unroll]

--- a/Lorenz_RK4/CPU_Julia/CPU_Lorenz_simple_julia.jl
+++ b/Lorenz_RK4/CPU_Julia/CPU_Lorenz_simple_julia.jl
@@ -1,10 +1,9 @@
-using DifferentialEquations, CPUTime, Statistics
+using DifferentialEquations, CPUTime, Statistics, SimpleDiffEq
 
 #settings
 const unroll = 128
 const numberOfParameters = 46080
 const numberOfRuns = 3
-nocheck(dt,u,p,t) = false
 
 #parameters and initial conditions
 parameterList = collect(range(0.0, stop = 21.0, length = numberOfParameters))
@@ -31,7 +30,7 @@ prob = ODEProblem(lorenz!, u0, tspan, p)
 
 solve(
   prob,
-  RK4(),
+  LoopRK4(),
   save_everystep = false,
   save_start = false,
   save_end = true,
@@ -52,7 +51,7 @@ for runs in 1:numberOfRuns
 
     solve(
       prob,
-      RK4(),
+      LoopRK4(),
       save_everystep = false,
       save_start = false,
       save_end = true,

--- a/Lorenz_RK4/CPU_Julia/CPU_Lorenz_simple_julia.jl
+++ b/Lorenz_RK4/CPU_Julia/CPU_Lorenz_simple_julia.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations, CPUTime, Statistics, SimpleDiffEq, MuladdMacro
+using DifferentialEquations, CPUTime, Statistics, SimpleDiffEq, LoopVectorization
 
 #settings
 const unroll = 128
@@ -16,7 +16,7 @@ end
 
 #ODE
 function lorenz!(du, u, p, t)
-    @muladd @inbounds for j in 1:unroll
+    @avx for j in 1:unroll
       du[j] = 10.0 * (u[j+unroll] - u[j])
       du[j+unroll] = p[j] * u[j] - u[j+unroll] - u[j] * u[j+2*unroll]
       du[j+2*unroll] = u[j] * u[j+unroll] - 2.66666666 * u[j+2*unroll]

--- a/Lorenz_RK4/GPU_Julia/GPU_Lorenz_julia.jl
+++ b/Lorenz_RK4/GPU_Julia/GPU_Lorenz_julia.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations, DiffEqGPU, CUDA, CPUTime, Statistics, SimpleDiffEq
+using DifferentialEquations, DiffEqGPU, CUDA, CPUTime, Statistics, MuladdMacro
 
 #settings
 const numberOfParameters = 46080
@@ -6,7 +6,7 @@ const unroll = 2
 const numberOfTrajectories = Int64(numberOfParameters/unroll)
 const batchSize = numberOfTrajectories
 const numberOfRuns = 2
-const gpuID = 0 #Nvidia titan black device
+const gpuID = 1 #Nvidia titan black device
 
 #select device
 CUDA.device!(gpuID)
@@ -29,7 +29,7 @@ end
 parameterList = range(0.0,stop = 21.0,length=numberOfParameters)
 p = zeros(unroll,1)
 tspan = (0.0,10.0)
-u0 = ones(unroll*3,1)
+u0 = ones(unroll*3)
 
 #parameter change function
 #parameterChange = (prob,i,repeat) -> remake(prob,p=parameterList[i]) #it has slightly more allocations
@@ -59,6 +59,7 @@ solve(
   dt = 0.01,
   dense = false
   )
+GC.gc()
 
 #simulation
 times = Vector{Float64}(undef,numberOfRuns)

--- a/Lorenz_RK4/GPU_Julia/GPU_Lorenz_simple_julia.jl
+++ b/Lorenz_RK4/GPU_Julia/GPU_Lorenz_simple_julia.jl
@@ -48,7 +48,7 @@ ensembleProb = EnsembleProblem(lorenzProblem,prob_func=parameterChange!)
 # compile
 solve(
   ensembleProb,
-  RK4(),
+  LoopRK4(),
   EnsembleGPUArray(),
   trajectories=Int64(numberOfParameters/unroll),
   batch_size = batchSize,
@@ -66,7 +66,7 @@ for runs in 1:numberOfRuns
   tStart = CPUtime_us()
   solve(
     ensembleProb,
-    RK4(),
+    LoopRK4(),
     EnsembleGPUArray(),
     trajectories=Int64(numberOfParameters/unroll),
     batch_size = batchSize,

--- a/Lorenz_RK4/GPU_Julia/GPU_Lorenz_simple_julia.jl
+++ b/Lorenz_RK4/GPU_Julia/GPU_Lorenz_simple_julia.jl
@@ -59,6 +59,7 @@ solve(
   dt = 0.01,
   dense = false
   )
+GC.gc()
 
 #simulation
 times = Vector{Float64}(undef,numberOfRuns)

--- a/Valve_RK45/CPU_Julia/CPU_Valve_julia_ensemble.jl
+++ b/Valve_RK45/CPU_Julia/CPU_Valve_julia_ensemble.jl
@@ -93,6 +93,20 @@ valveODE = ODEProblem(valve!,y0,tSpan,q)
 cb = VectorContinuousCallback(condition,local_min!,2,affect_neg! = local_max!)
 ensemble_prob = EnsembleProblem(valveODE,prob_func = parameter_change!)
 
+# Compile once
+res = solve(
+    ensemble_prob,
+    DP5(),
+    EnsembleSerial(),
+    callback = cb,
+    abstol = 1e-10,
+    reltol = 1e-10,
+    trajectories= numberOfParameters,
+    save_everystep = false,
+    save_start = false,
+    save_end = true,
+    maxiters = 1e8,
+    dtmin = 1e-12)
 
 times =  Vector{Float64}(undef,numberOfRuns)
 for runs in 1:numberOfRuns

--- a/Valve_RK45/CPU_Julia/CPU_Valve_julia_loop.jl
+++ b/Valve_RK45/CPU_Julia/CPU_Valve_julia_loop.jl
@@ -55,6 +55,24 @@ cb = VectorContinuousCallback(
 global outputData = zeros(numberOfParameters,numberOfSaves*2);
 global lastVals = [0.0,1.0,2.0,3.0]
 
+#compile once
+tSpan = [0.0,1e10]
+y0 = [0.2,0.0,0.0]
+q[1] = parameterList[par]
+valveODE = ODEProblem(valve!,y0,tSpan,q)
+res = solve(
+    valveODE,
+    DP5(),
+    callback = cb,
+    abstol = 1e-10,
+    reltol = 1e-10,
+    save_everystep = false,
+    save_start = false,
+    save_end = true,
+    maxiters = 1e8,
+    dense=false,
+    dtmin = 1e-12)
+
 #simulation
 times =  Vector{Float64}(undef,numberOfRuns)
 for runs in 1:numberOfRuns

--- a/Valve_RK45/GPU_Julia/GPU_Valve_julia.jl
+++ b/Valve_RK45/GPU_Julia/GPU_Valve_julia.jl
@@ -1,4 +1,4 @@
-using DifferentialEquations, DiffEqGPU, CUDAnative, CuArrays, CUDAdrv, CPUTime, Plots, DelimitedFiles
+using DifferentialEquations, DiffEqGPU, CUDA, CPUTime, Plots, DelimitedFiles
 
 """
 Warning:
@@ -107,6 +107,20 @@ valveODE = ODEProblem(valve!,y0,tSpan,q)
 cb = VectorContinuousCallback(condition,local_min!,2,affect_neg! = local_max!)
 ensemble_prob = EnsembleProblem(valveODE,prob_func = parameter_change!)
 
+#compile
+res = solve(
+    ensemble_prob,
+    DP5(),
+    EnsembleGPUArray(),
+    callback = cb,
+    abstol = 1e-10,
+    reltol = 1e-10,
+    trajectories= numberOfParameters,
+    save_everystep = false,
+    save_start = false,
+    save_end = true,
+    maxiters = 1e8,
+    dtmin = 1e-12)
 
 times =  Vector{Float64}(undef,numberOfRuns)
 for runs in 1:numberOfRuns


### PR DESCRIPTION
This is fun. Thank you for putting these together: tiny kernel optimizations is a use case the dynamical systems crowd has been interested in so this is a good opportunity to dig in and really understand the current performance and limitations. I'll need to call in @chriselrod, @jpsamaroo, and @vchuravy as our CPU and GPU kernel engineers to take a look at this, but I optimized these by what seems like more than an order of magnitude in a few cases so would be nice if the full graph can be regenerated. A few things to note:

1. For the Julia codes, compilation seemed like it was in the timing but I didn't see timing of the C++ compilation process, so I think that might've been a mistake. I pulled out the compilation process from the timing, but that part can be deleted if the C++ compilation is also timed.
2. There was a pretty massive performance increase from moving DiffEqGPU from GPUifyLoops to KernalAbstractions, which accounts for most of the GPU change.
3. This is more of a note for @vchuravy, the "speed of light" to consider here is the odeint kernels since I think they are taking the same approach as `EnsembleGPUArray`, more on that in a sec.
4. In the plot labels, it shouldn't just say "DifferentialEquations.jl" since DifferentialEquations.jl is an interface with many algorithms and packages instantiating the interface. It should be OrdinaryDiffEq.RK4, and EnsembleGPUArray.
5. I added the use of SimpleDiffEq.jl since I was adding some simple RK4's for course notes. These are the RK4s that were added with `_simple`. `LoopRK4` ends up being a very nice baseline that pulls out any possible overhead of OrdinaryDiffEq.jl's more expansive system. It's pretty dead simple: https://github.com/SciML/SimpleDiffEq.jl/blob/master/src/rk4/looprk4.jl#L70-L126 . If that doesn't hit something pretty optimal, then I'd be curious to see what kind of vectorization we can get through some kind of reordering, and if it's significant then this might be a new ensemble choice we might want to offer. So @chriselrod it would be nice if you could take a look at that. It looks like `@avx` didn't do any magic here, so it might need to be changed at a different level of the compiler?

Part of the reason to be more specific with the labeling is because we're trying to get a new form of GPU ensembling up and running, `EnsembleGPUAsync` which is more like MPGOS by being fully asynchronous between the integrators. The current approach just pools all of the solves into a bigger ODE/SDE/DDE/DAE which has advantages and disadvantages. The advantage is that all of the logic is on the CPU, which could be useful in the case of implicit solvers (which is what it was originally optimized for) where there's a bunch more logic. But the bad is that everything has to resync at every step update, which on non-stiff ODEs is very sub-optimal since you don't have the LU time to cover it. It's note fully working yet though (https://github.com/SciML/DiffEqGPU.jl/pull/74), but the change to KernelAbstraction.jl has gotten it fairly far and probably a little bit of help from @jpsamaroo and @vchuravy is probably all that's needed. I'd be quite curious to see how close a purely generated kernel gets to MPGOS.